### PR TITLE
update saucelabs connect to 4.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "node": ">= 0.10.x"
   },
   "sauceConnectLauncher": {
-    "scVersion": "4.3.16"
+    "scVersion": "4.4.0"
   }
 }


### PR DESCRIPTION
```sh
23 Sep 09:08:51 - ***********************************************************
23 Sep 09:08:51 - A newer version of Sauce Connect (build 2865) is available!
23 Sep 09:08:51 - Download it here:
23 Sep 09:08:51 - https://saucelabs.com/downloads/sc-4.4.0-osx.zip
23 Sep 09:08:51 - ***********************************************************
```